### PR TITLE
Fix: Jitpack support

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/transformerkt/build.gradle.kts
+++ b/transformerkt/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.dokka")
+    id("maven-publish")
 }
 
 android {
@@ -54,4 +55,17 @@ dependencies {
 
     /* Misc */
     dokkaPlugin(libs.android.documentation.plugin)
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = "dev.transformerkt"
+            artifactId = "transformerkt"
+
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
 }


### PR DESCRIPTION
Jitpack is currently broken when using kotlin gradle scripts, so we need to manually add `maven-publish` and configure it. As well as set the jdk to use in `jitpack.yml`