### PR TITLE
Chore: Deprecate using a TransformerRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ You can view the TransformerKt KDocs at [docs.transformerkt.dev](https://docs.tr
 - [Motivation](#motivation)
 - [Getting Started](#getting-started)
 - [Usage](#usage)
-- [Transform Requests](#transform-requests)
 - [Applying Effects](#applying-effects)
 - [Composition](#composition)
 - [Demo App](#demo-app)
@@ -112,8 +111,10 @@ There are overloads for each of the supported inputs. For example:
 ```kotlin
 suspend fun transform(context: Context, input: Uri) {
     val output = File(context.filesDir, "output.mp4")
-    val transformer = Transformer.Builder(context).build()
-    val result = transformer.start(input, output, TransformerKt.H264Request) { progress ->
+    val transformer = TransformerKt.build(context) {
+        setVideoMimeType(MimeTypes.VIDEO_H264)
+    }
+    val result = transformer.start(input, output) { progress ->
         // Update UI progress
     }
     when (result) {
@@ -128,8 +129,8 @@ Or you can use the `Flow` version instead:
 ```kotlin
 fun transform(context: Context, input: Uri) {
     val output = File(context.filesDir, "output.mp4")
-    val transformer = Transformer.Builder(context).build()
-    transformer.start(input, output, TransformerKt.H264Request).collect { status ->
+    val transformer = Transformer.build(context) { setVideoMimeType(MimeTypes.VIDEO_H264) }
+    transformer.start(input, output).collect { status ->
         when (status) {
             is TransformerStatus.Progress -> TODO()
             is TransformerStatus.Success -> TODO()
@@ -139,56 +140,14 @@ fun transform(context: Context, input: Uri) {
 }
 ```
 
-## Transform Requests
-
-Now that you understand _how_ to use the library, you need to understand _what_ you can do with it.
-
-First take a look at
-the [Transformer Transformation Docs](https://developer.android.com/guide/topics/media/transformer/transformations)
-so you can see what is possible.
-
-**Note:** The documentation is currently not up to date with the latest version of `media3`. So some
-things may be different.
-
-By default, the library uses a default instance of `TransformationRequest` which most likely will
-not do anything to your input file. Therefore you need to provide your own `TransformationRequest`
-to the library, or use one of the predefined ones.
-
-Currently `TransformerKt` ships with:
-
-- `TransformerKt.H264Request`
-    - Converts the input to an H264 encoded MP4 file.
-- `TransformerKt.H264AndAacRequest`
-    - Converts the input to an H264 encoded MP4 file, with AAC audio.
-
-### Example Requests
-
-You can modify this request by using the provided `buildWith {}` extension function
-for `TransformationRequest.Builder`.
-
-Convert a video to an H264 encoded MP4 file, with AAC audio:
-
-```kotlin
-val request = TransformerKt.H264Request.buildWith {
-    setAudioMimeType(MimeTypes.AUDIO_AAC)
-}
-```
-
-Convert a HDR video to a SDR video:
-
-```kotlin
-val request = TransformerKt.H264Request.buildWith {
-    setHdrMode(TransformationRequest.HDR_MODE_TONE_MAP_HDR_TO_SDR_USING_OPEN_GL)
-}
-```
-
 ## Applying Effects
 
 Starting with version `1.1.0-alpha01`, the `Transformer` library changed the way you apply effects.
 Instead of applying the effects to the `Transformer.Builder` you now create a `EditedMediaItem` and
 apply the affects there.
 
-To make that API a bit easier, an extension function `.edited {}` has been added to `MediaItem.Builder`:
+To make that API a bit easier, an extension function `.edited {}` has been added
+to `MediaItem.Builder`:
 
 ```kotlin
 val editedMediaItem = MediaItem.Builder()

--- a/demo/src/main/java/dev/transformerkt/demo/transformer/TransformerRepo.kt
+++ b/demo/src/main/java/dev/transformerkt/demo/transformer/TransformerRepo.kt
@@ -34,7 +34,9 @@ class TransformerRepo @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    private val transformer = TransformerKt.build(context)
+    private val transformer = TransformerKt.build(context) {
+        setTransformationRequest()
+    }
 
     suspend fun convertToSdr(
         input: VideoDetails,

--- a/demo/src/main/java/dev/transformerkt/demo/transformer/TransformerRepo.kt
+++ b/demo/src/main/java/dev/transformerkt/demo/transformer/TransformerRepo.kt
@@ -34,9 +34,7 @@ class TransformerRepo @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    private val transformer = TransformerKt.build(context) {
-        setTransformationRequest()
-    }
+    private val transformer = TransformerKt.build(context)
 
     suspend fun convertToSdr(
         input: VideoDetails,

--- a/transformerkt/api/transformerkt.api
+++ b/transformerkt/api/transformerkt.api
@@ -40,54 +40,39 @@ public final class dev/transformerkt/TransformerStatus$Success : dev/transformer
 }
 
 public abstract interface class dev/transformerkt/dsl/composition/CompositionBuilder {
+	public abstract fun add (Landroid/net/Uri;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public abstract fun add (Landroidx/media3/common/MediaItem;ZLkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public abstract fun add (Landroidx/media3/transformer/EditedMediaItem;Z)Ldev/transformerkt/dsl/composition/CompositionBuilder;
 	public abstract fun add (Landroidx/media3/transformer/EditedMediaItemSequence;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
-	public abstract fun add (ZLandroidx/media3/transformer/EditedMediaItem;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
-	public abstract fun add (ZLkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public abstract fun add (Ljava/io/File;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
 	public abstract fun build ()Landroidx/media3/transformer/Composition;
 	public abstract fun effects (Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
 	public abstract fun getForceAudioTrack ()Z
 	public abstract fun getHdrMode ()I
 	public abstract fun getTransmuxAudio ()Z
 	public abstract fun getTransmuxVideo ()Z
+	public abstract fun getVideoCompositorSettings ()Landroidx/media3/effect/VideoCompositorSettings;
 	public abstract fun sequenceOf (ZLkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
 	public abstract fun setForceAudioTrack (Z)V
 	public abstract fun setHdrMode (I)V
 	public abstract fun setTransmuxAudio (Z)V
 	public abstract fun setTransmuxVideo (Z)V
+	public abstract fun setVideoCompositorSettings (Landroidx/media3/effect/VideoCompositorSettings;)V
 }
 
 public final class dev/transformerkt/dsl/composition/CompositionBuilder$DefaultImpls {
-	public static fun add (Ldev/transformerkt/dsl/composition/CompositionBuilder;ZLandroidx/media3/transformer/EditedMediaItem;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
-	public static synthetic fun add$default (Ldev/transformerkt/dsl/composition/CompositionBuilder;ZLandroidx/media3/transformer/EditedMediaItem;ILjava/lang/Object;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
-	public static synthetic fun add$default (Ldev/transformerkt/dsl/composition/CompositionBuilder;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public static fun add (Ldev/transformerkt/dsl/composition/CompositionBuilder;Landroid/net/Uri;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public static fun add (Ldev/transformerkt/dsl/composition/CompositionBuilder;Landroidx/media3/common/MediaItem;ZLkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public static fun add (Ldev/transformerkt/dsl/composition/CompositionBuilder;Ljava/io/File;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public static synthetic fun add$default (Ldev/transformerkt/dsl/composition/CompositionBuilder;Landroid/net/Uri;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public static synthetic fun add$default (Ldev/transformerkt/dsl/composition/CompositionBuilder;Landroidx/media3/common/MediaItem;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public static synthetic fun add$default (Ldev/transformerkt/dsl/composition/CompositionBuilder;Landroidx/media3/transformer/EditedMediaItem;ZILjava/lang/Object;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
+	public static synthetic fun add$default (Ldev/transformerkt/dsl/composition/CompositionBuilder;Ljava/io/File;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
 	public static synthetic fun sequenceOf$default (Ldev/transformerkt/dsl/composition/CompositionBuilder;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/transformerkt/dsl/composition/CompositionBuilder;
 }
 
 public final class dev/transformerkt/dsl/composition/CompositionBuilderKt {
 	public static final fun compositionOf (Lkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/Composition;
-}
-
-public abstract interface class dev/transformerkt/dsl/composition/EditedMediaItemBuilder {
-	public abstract fun image (Landroid/net/Uri;JILkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public abstract fun image (Ljava/io/File;JILkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public abstract fun image (Ljava/lang/String;JILkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public abstract fun item (Landroid/net/Uri;Lkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public abstract fun item (Ljava/io/File;Lkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public abstract fun item (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-}
-
-public final class dev/transformerkt/dsl/composition/EditedMediaItemBuilder$DefaultImpls {
-	public static fun image (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Landroid/net/Uri;JILkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public static fun image (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/io/File;JILkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public static fun image (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/lang/String;JILkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public static synthetic fun image$default (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Landroid/net/Uri;JILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/media3/transformer/EditedMediaItem;
-	public static synthetic fun image$default (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/io/File;JILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/media3/transformer/EditedMediaItem;
-	public static synthetic fun image$default (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/lang/String;JILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/media3/transformer/EditedMediaItem;
-	public static fun item (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/io/File;Lkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public static fun item (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Landroidx/media3/transformer/EditedMediaItem;
-	public static synthetic fun item$default (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/media3/transformer/EditedMediaItem;
-	public static synthetic fun item$default (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/io/File;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/media3/transformer/EditedMediaItem;
-	public static synthetic fun item$default (Ldev/transformerkt/dsl/composition/EditedMediaItemBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/media3/transformer/EditedMediaItem;
 }
 
 public final class dev/transformerkt/dsl/composition/SequenceBuilder {
@@ -144,6 +129,7 @@ public final class dev/transformerkt/dsl/effects/OverlaySettingsKt {
 	public static final fun bitmapOverlay (Ldev/transformerkt/dsl/effects/EffectsBuilder;Landroid/content/Context;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/effects/EffectsBuilder;
 	public static final fun bitmapOverlay (Ldev/transformerkt/dsl/effects/EffectsBuilder;Landroid/graphics/Bitmap;Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/effects/EffectsBuilder;
 	public static final fun overlaySettings (Ldev/transformerkt/dsl/effects/EffectsBuilder;Lkotlin/jvm/functions/Function1;)Landroidx/media3/effect/OverlaySettings;
+	public static final fun textOverlay (Ldev/transformerkt/dsl/effects/EffectsBuilder;Landroid/text/SpannableString;Lkotlin/jvm/functions/Function1;)Ldev/transformerkt/dsl/effects/EffectsBuilder;
 }
 
 public final class dev/transformerkt/ktx/CompositionKt {
@@ -246,6 +232,7 @@ public final class dev/transformerkt/ktx/effects/SpeedKt {
 }
 
 public final class dev/transformerkt/ktx/effects/TextOverlayKt {
+	public static final fun buildSpannableString (Lkotlin/jvm/functions/Function1;)Landroid/text/SpannableString;
 	public static final fun textOverlay (Ldev/transformerkt/dsl/effects/EffectsBuilder;Landroid/text/SpannableString;Landroidx/media3/effect/OverlaySettings;)Ldev/transformerkt/dsl/effects/EffectsBuilder;
 	public static synthetic fun textOverlay$default (Ldev/transformerkt/dsl/effects/EffectsBuilder;Landroid/text/SpannableString;Landroidx/media3/effect/OverlaySettings;ILjava/lang/Object;)Ldev/transformerkt/dsl/effects/EffectsBuilder;
 	public static final fun textOverlayEffect (Landroid/text/SpannableString;Landroidx/media3/effect/OverlaySettings;)Landroidx/media3/effect/OverlayEffect;
@@ -260,44 +247,72 @@ public final class dev/transformerkt/ktx/effects/VolumeKt {
 }
 
 public final class dev/transformerkt/ktx/inputs/CompositionKt {
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;J)Lkotlinx/coroutines/flow/Flow;
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/Composition;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/transformerkt/ktx/inputs/EditedMediaItemKt {
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;J)Lkotlinx/coroutines/flow/Flow;
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/transformer/EditedMediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/transformerkt/ktx/inputs/FileKt {
+	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun start (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;J)Lkotlinx/coroutines/flow/Flow;
+	public static final fun start (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Ljava/io/File;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/transformerkt/ktx/inputs/MediaItemKt {
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;J)Lkotlinx/coroutines/flow/Flow;
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroidx/media3/common/MediaItem;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class dev/transformerkt/ktx/inputs/UriKt {
+	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun imageToVideo (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun imageToVideo$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JIJLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;J)Lkotlinx/coroutines/flow/Flow;
+	public static final fun start (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;J)Lkotlinx/coroutines/flow/Flow;
 	public static final fun start (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun start$default (Landroidx/media3/transformer/Transformer;Landroid/net/Uri;Ljava/io/File;Landroidx/media3/transformer/TransformationRequest;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }

--- a/transformerkt/src/main/java/dev/transformerkt/TransformerKt.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/TransformerKt.kt
@@ -40,11 +40,13 @@ public object TransformerKt {
     /**
      * A [TransformationRequest] that uses the default values.
      */
+    @Deprecated("Use setAudioMimeType(String), setVideoMimeType(String) and Composition.Builder.setHdrMode(int) instead")
     public val InferRequest: TransformationRequest = TransformationRequest.Builder().build()
 
     /**
      * A [TransformationRequest] that transforms the video to H264.
      */
+    @Deprecated("Use setAudioMimeType(String), setVideoMimeType(String) and Composition.Builder.setHdrMode(int) instead")
     public val H264Request: TransformationRequest = TransformationRequest.Builder()
         .setVideoMimeType(MimeTypes.VIDEO_H264)
         .build()
@@ -52,10 +54,12 @@ public object TransformerKt {
     /**
      * A [TransformationRequest] that transforms the video to H264 and audio to AAC.
      */
+    @Deprecated("Use setAudioMimeType(String), setVideoMimeType(String) and Composition.Builder.setHdrMode(int) instead")
     public val H264AndAacRequest: TransformationRequest = H264Request.buildWith {
         setAudioMimeType(MimeTypes.AUDIO_AAC)
     }
 
+    @Deprecated("Use setAudioMimeType(String), setVideoMimeType(String) and Composition.Builder.setHdrMode(int) instead")
     public val DefaultRequest: TransformationRequest = InferRequest
 
     /**

--- a/transformerkt/src/main/java/dev/transformerkt/internal/Transformer.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/internal/Transformer.kt
@@ -17,7 +17,6 @@ import java.io.File
  * @see createTransformerCallbackFlow
  * @param[input] The input to transform.
  * @param[output] The output file to write to.
- * @param[request] The [TransformationRequest] to use.
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @return A [Flow] that emits [TransformerStatus].
  */
@@ -25,12 +24,10 @@ import java.io.File
 internal fun Transformer.start(
     input: TransformerInput,
     output: File,
-    request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
 ): Flow<TransformerStatus> = createTransformerCallbackFlow(
     input = input,
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
 )
 
@@ -43,7 +40,6 @@ internal fun Transformer.start(
  * @see start
  * @param[input] The input to transform.
  * @param[output] The output file to write to.
- * @param[request] The [TransformationRequest] to use.
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
@@ -51,7 +47,6 @@ internal fun Transformer.start(
 internal suspend fun Transformer.start(
     input: TransformerInput,
     output: File,
-    request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
     onProgress: (Int) -> Unit = {},
 ): TransformerStatus.Finished {
@@ -59,7 +54,6 @@ internal suspend fun Transformer.start(
         val result: TransformerStatus? = start(
             input = input,
             output = output,
-            request = request,
             progressPollDelayMs = progressPollDelayMs,
         ).onEach { status ->
             if (status is TransformerStatus.Progress) {

--- a/transformerkt/src/main/java/dev/transformerkt/internal/TransformerListener.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/internal/TransformerListener.kt
@@ -6,7 +6,6 @@ import androidx.media3.transformer.Composition
 import androidx.media3.transformer.ExportException
 import androidx.media3.transformer.ExportResult
 import androidx.media3.transformer.ProgressHolder
-import androidx.media3.transformer.TransformationRequest
 import androidx.media3.transformer.Transformer
 import dev.transformerkt.TransformerKt
 import dev.transformerkt.TransformerStatus
@@ -34,14 +33,12 @@ import java.io.File
  * @receiver The [Transformer] instance to start a transformation.
  * @param[input] The input to transform.
  * @param[output] The output file to write to.
- * @param[request] The [TransformationRequest] to use.
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @return A [Flow] that emits [TransformerStatus].
  */
 internal fun Transformer.createTransformerCallbackFlow(
     input: TransformerInput,
     output: File,
-    request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
 ): Flow<TransformerStatus> {
     val oldTransformer = this
@@ -68,9 +65,6 @@ internal fun Transformer.createTransformerCallbackFlow(
         val transformer = oldTransformer
             .buildWith {
                 removeAllListeners()
-//                setTransformationRequest(request)
-                request.audioMimeType?.let { setAudioMimeType(it) }
-                request.videoMimeType?.let { setVideoMimeType(it) }
                 addListener(listener)
             }
             .startWith(input, output)

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/Composition.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/Composition.kt
@@ -22,16 +22,35 @@ import java.io.File
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @return A [Flow] that emits [TransformerStatus].
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs)"),
+)
 @CheckResult
 public fun Transformer.start(
     input: Composition,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+): Flow<TransformerStatus> = start(input, output, progressPollDelayMs)
+
+/**
+ * Start a [Transformer] request for a [Composition] and return a [Flow] of [TransformerStatus].
+ *
+ * @see createTransformerCallbackFlow
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @return A [Flow] that emits [TransformerStatus].
+ */
+@CheckResult
+public fun Transformer.start(
+    input: Composition,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
 ): Flow<TransformerStatus> = start(
     input = TransformerInput.Composition(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
 )
 
@@ -49,16 +68,39 @@ public fun Transformer.start(
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs, onProgress)"),
+)
 public suspend fun Transformer.start(
     input: Composition,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
     onProgress: (Int) -> Unit = {},
+): TransformerStatus.Finished = start(input, output, progressPollDelayMs, onProgress)
+
+/**
+ * Start a [Transformer] request for a [Composition] in a coroutine and return
+ * a [TransformerStatus.Finished] when the request is finished.
+ *
+ * For progress updates pass a [onProgress] callback.
+ *
+ * @see start
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[onProgress] The callback to use for progress updates.
+ * @return A [TransformerStatus.Finished] status.
+ */
+public suspend fun Transformer.start(
+    input: Composition,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    onProgress: (Int) -> Unit = {},
 ): TransformerStatus.Finished = start(
     input = TransformerInput.Composition(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
     onProgress = onProgress,
 )

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/EditedMediaItem.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/EditedMediaItem.kt
@@ -22,16 +22,36 @@ import java.io.File
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @return A [Flow] that emits [TransformerStatus].
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs)"),
+)
 @CheckResult
 public fun Transformer.start(
     input: EditedMediaItem,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+): Flow<TransformerStatus> = start(input, output, progressPollDelayMs)
+
+
+/**
+ * Start a [Transformer] request for a [EditedMediaItem] and return a [Flow] of [TransformerStatus].
+ *
+ * @see createTransformerCallbackFlow
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @return A [Flow] that emits [TransformerStatus].
+ */
+@CheckResult
+public fun Transformer.start(
+    input: EditedMediaItem,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
 ): Flow<TransformerStatus> = start(
     input = TransformerInput.EditedMediaItem(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
 )
 
@@ -49,16 +69,39 @@ public fun Transformer.start(
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs, onProgress)"),
+)
 public suspend fun Transformer.start(
     input: EditedMediaItem,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
     onProgress: (Int) -> Unit = {},
+): TransformerStatus.Finished = start(input, output, progressPollDelayMs, onProgress)
+
+/**
+ * Start a [Transformer] request for a [EditedMediaItem] in a coroutine and return
+ * a [TransformerStatus.Finished] when the request is finished.
+ *
+ * For progress updates pass a [onProgress] callback.
+ *
+ * @see start
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[onProgress] The callback to use for progress updates.
+ * @return A [TransformerStatus.Finished] status.
+ */
+public suspend fun Transformer.start(
+    input: EditedMediaItem,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    onProgress: (Int) -> Unit = {},
 ): TransformerStatus.Finished = start(
     input = TransformerInput.EditedMediaItem(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
     onProgress = onProgress,
 )

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/File.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/File.kt
@@ -23,16 +23,35 @@ import java.io.File
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @return A [Flow] that emits [TransformerStatus].
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs)"),
+)
 @CheckResult
 public fun Transformer.start(
     input: File,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+): Flow<TransformerStatus> = start(input, output, progressPollDelayMs)
+
+/**
+ * Start a [Transformer] request for a [File] and return a [Flow] of [TransformerStatus].
+ *
+ * @see createTransformerCallbackFlow
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @return A [Flow] that emits [TransformerStatus].
+ */
+@CheckResult
+public fun Transformer.start(
+    input: File,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
 ): Flow<TransformerStatus> = start(
     input = TransformerInput.File(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
 )
 
@@ -50,11 +69,39 @@ public fun Transformer.start(
  * @param[effectsBlock] A block to customize the effects for the final video.
  * @return A [Flow] that emits [TransformerStatus].
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("imageToVideo(input, output, durationMs, frameRate, progressPollDelayMs, effectsBlock)"),
+)
 @CheckResult
 public fun Transformer.imageToVideo(
     input: File,
     output: File,
     request: TransformationRequest,
+    durationMs: Long,
+    frameRate: Int = 30,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    effectsBlock: EffectsBuilder.() -> Unit = {},
+): Flow<TransformerStatus> =
+    imageToVideo(input, output, durationMs, frameRate, progressPollDelayMs, effectsBlock)
+
+/**
+ * Convert an image to a video.
+ *
+ * Use [effectsBlock] to customize the effects for the final video.
+ *
+ * @param[input] The input image to transform.
+ * @param[output] The output file to write to.
+ * @param[durationMs] The duration of the final video.
+ * @param[frameRate] The frame rate of the final video.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[effectsBlock] A block to customize the effects for the final video.
+ * @return A [Flow] that emits [TransformerStatus].
+ */
+@CheckResult
+public fun Transformer.imageToVideo(
+    input: File,
+    output: File,
     durationMs: Long,
     frameRate: Int = 30,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
@@ -69,7 +116,6 @@ public fun Transformer.imageToVideo(
     return start(
         input = composition,
         output = output,
-        request = request,
         progressPollDelayMs = progressPollDelayMs,
     )
 }
@@ -88,16 +134,39 @@ public fun Transformer.imageToVideo(
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs, onProgress)"),
+)
 public suspend fun Transformer.start(
     input: File,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
     onProgress: (Int) -> Unit = {},
+): TransformerStatus.Finished = start(input, output, progressPollDelayMs, onProgress)
+
+/**
+ * Start a [Transformer] request for a [File] in a coroutine and return
+ * a [TransformerStatus.Finished] when the request is finished.
+ *
+ * For progress updates pass a [onProgress] callback.
+ *
+ * @see start
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[onProgress] The callback to use for progress updates.
+ * @return A [TransformerStatus.Finished] status.
+ */
+public suspend fun Transformer.start(
+    input: File,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    onProgress: (Int) -> Unit = {},
 ): TransformerStatus.Finished = start(
     input = TransformerInput.File(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
     onProgress = onProgress,
 )
@@ -117,10 +186,39 @@ public suspend fun Transformer.start(
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("imageToVideo(input, output, durationMs, frameRate, progressPollDelayMs, effectsBlock, onProgress)"),
+)
 public suspend fun Transformer.imageToVideo(
     input: File,
     output: File,
     request: TransformationRequest,
+    durationMs: Long,
+    frameRate: Int = 30,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    effectsBlock: EffectsBuilder.() -> Unit = {},
+    onProgress: (Int) -> Unit = {},
+): TransformerStatus.Finished =
+    imageToVideo(input, output, durationMs, frameRate, progressPollDelayMs, effectsBlock, onProgress)
+
+/**
+ * Convert an image to a video in a coroutine.
+ *
+ * Use [effectsBlock] to customize the effects for the final video.
+ *
+ * @param[input] The input image to transform.
+ * @param[output] The output file to write to.
+ * @param[durationMs] The duration of the final video.
+ * @param[frameRate] The frame rate of the final video.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[effectsBlock] A block to customize the effects for the final video.
+ * @param[onProgress] The callback to use for progress updates.
+ * @return A [TransformerStatus.Finished] status.
+ */
+public suspend fun Transformer.imageToVideo(
+    input: File,
+    output: File,
     durationMs: Long,
     frameRate: Int = 30,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
@@ -136,7 +234,6 @@ public suspend fun Transformer.imageToVideo(
     return start(
         input = composition,
         output = output,
-        request = request,
         progressPollDelayMs = progressPollDelayMs,
         onProgress = onProgress,
     )

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/MediaItem.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/MediaItem.kt
@@ -22,16 +22,35 @@ import java.io.File
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @return A [Flow] that emits [TransformerStatus].
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs)"),
+)
 @CheckResult
 public fun Transformer.start(
     input: MediaItem,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+): Flow<TransformerStatus> = start(input, output, progressPollDelayMs)
+
+/**
+ * Start a [Transformer] request for a [MediaItem] and return a [Flow] of [TransformerStatus].
+ *
+ * @see createTransformerCallbackFlow
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @return A [Flow] that emits [TransformerStatus].
+ */
+@CheckResult
+public fun Transformer.start(
+    input: MediaItem,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
 ): Flow<TransformerStatus> = start(
     input = TransformerInput.MediaItem(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
 )
 
@@ -49,16 +68,39 @@ public fun Transformer.start(
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs)"),
+)
 public suspend fun Transformer.start(
     input: MediaItem,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
     onProgress: (Int) -> Unit = {},
+): TransformerStatus.Finished = start(input, output, progressPollDelayMs, onProgress)
+
+/**
+ * Start a [Transformer] request for a [MediaItem] in a coroutine and return
+ * a [TransformerStatus.Finished] when the request is finished.
+ *
+ * For progress updates pass a [onProgress] callback.
+ *
+ * @see start
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[onProgress] The callback to use for progress updates.
+ * @return A [TransformerStatus.Finished] status.
+ */
+public suspend fun Transformer.start(
+    input: MediaItem,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    onProgress: (Int) -> Unit = {},
 ): TransformerStatus.Finished = start(
     input = TransformerInput.MediaItem(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
     onProgress = onProgress,
 )

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/Uri.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/inputs/Uri.kt
@@ -24,16 +24,35 @@ import java.io.File
  * @param[progressPollDelayMs] The delay between polling for progress.
  * @return A [Flow] that emits [TransformerStatus].
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs)"),
+)
 @CheckResult
 public fun Transformer.start(
     input: Uri,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+): Flow<TransformerStatus> = start(input, output, progressPollDelayMs)
+
+/**
+ * Start a [Transformer] request for a [Uri] and return a [Flow] of [TransformerStatus].
+ *
+ * @see createTransformerCallbackFlow
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @return A [Flow] that emits [TransformerStatus].
+ */
+@CheckResult
+public fun Transformer.start(
+    input: Uri,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
 ): Flow<TransformerStatus> = start(
     input = TransformerInput.Uri(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
 )
 
@@ -51,11 +70,39 @@ public fun Transformer.start(
  * @param[effectsBlock] A block to customize the effects for the final video.
  * @return A [Flow] that emits [TransformerStatus].
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("imageToVideo(input, output, durationMs, frameRate, progressPollDelayMs, effectsBlock)"),
+)
 @CheckResult
 public fun Transformer.imageToVideo(
     input: Uri,
     output: File,
     request: TransformationRequest,
+    durationMs: Long,
+    frameRate: Int = 30,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    effectsBlock: EffectsBuilder.() -> Unit = {},
+): Flow<TransformerStatus> =
+    imageToVideo(input, output, durationMs, frameRate, progressPollDelayMs, effectsBlock)
+
+/**
+ * Convert an image to a video.
+ *
+ * Use [effectsBlock] to customize the effects for the final video.
+ *
+ * @param[input] The input image to transform.
+ * @param[output] The output file to write to.
+ * @param[durationMs] The duration of the final video.
+ * @param[frameRate] The frame rate of the final video.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[effectsBlock] A block to customize the effects for the final video.
+ * @return A [Flow] that emits [TransformerStatus].
+ */
+@CheckResult
+public fun Transformer.imageToVideo(
+    input: Uri,
+    output: File,
     durationMs: Long,
     frameRate: Int = 30,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
@@ -70,7 +117,6 @@ public fun Transformer.imageToVideo(
     return start(
         input = composition,
         output = output,
-        request = request,
         progressPollDelayMs = progressPollDelayMs,
     )
 }
@@ -89,16 +135,39 @@ public fun Transformer.imageToVideo(
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs, onProgress)"),
+)
 public suspend fun Transformer.start(
     input: Uri,
     output: File,
     request: TransformationRequest,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
     onProgress: (Int) -> Unit = {},
+): TransformerStatus.Finished = start(input, output, progressPollDelayMs, onProgress)
+
+/**
+ * Start a [Transformer] request for a [Uri] in a coroutine and return
+ * a [TransformerStatus.Finished] when the request is finished.
+ *
+ * For progress updates pass a [onProgress] callback.
+ *
+ * @see start
+ * @param[input] The input to transform.
+ * @param[output] The output file to write to.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[onProgress] The callback to use for progress updates.
+ * @return A [TransformerStatus.Finished] status.
+ */
+public suspend fun Transformer.start(
+    input: Uri,
+    output: File,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    onProgress: (Int) -> Unit = {},
 ): TransformerStatus.Finished = start(
     input = TransformerInput.Uri(input),
     output = output,
-    request = request,
     progressPollDelayMs = progressPollDelayMs,
     onProgress = onProgress,
 )
@@ -118,10 +187,39 @@ public suspend fun Transformer.start(
  * @param[onProgress] The callback to use for progress updates.
  * @return A [TransformerStatus.Finished] status.
  */
+@Deprecated(
+    "Using TransformerRequest has been deprecated",
+    ReplaceWith("start(input, output, progressPollDelayMs, onProgress)"),
+)
 public suspend fun Transformer.imageToVideo(
     input: Uri,
     output: File,
     request: TransformationRequest,
+    durationMs: Long,
+    frameRate: Int = 30,
+    progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
+    effectsBlock: EffectsBuilder.() -> Unit = {},
+    onProgress: (Int) -> Unit = {},
+): TransformerStatus.Finished =
+    imageToVideo(input, output, durationMs, frameRate, progressPollDelayMs, effectsBlock, onProgress)
+
+/**
+ * Convert an image to a video in a coroutine.
+ *
+ * Use [effectsBlock] to customize the effects for the final video.
+ *
+ * @param[input] The input image to transform.
+ * @param[output] The output file to write to.
+ * @param[durationMs] The duration of the final video.
+ * @param[frameRate] The frame rate of the final video.
+ * @param[progressPollDelayMs] The delay between polling for progress.
+ * @param[effectsBlock] A block to customize the effects for the final video.
+ * @param[onProgress] The callback to use for progress updates.
+ * @return A [TransformerStatus.Finished] status.
+ */
+public suspend fun Transformer.imageToVideo(
+    input: Uri,
+    output: File,
     durationMs: Long,
     frameRate: Int = 30,
     progressPollDelayMs: Long = TransformerKt.DEFAULT_PROGRESS_POLL_DELAY_MS,
@@ -137,7 +235,6 @@ public suspend fun Transformer.imageToVideo(
     return start(
         input = composition,
         output = output,
-        request = request,
         progressPollDelayMs = progressPollDelayMs,
         onProgress = onProgress,
     )


### PR DESCRIPTION
`androidx.media.transformer` has deprecated using a `TransformerRequest` with the `Transformer.Builder`:

> Deprecated Use setAudioMimeType(String), setVideoMimeType(String) and Composition.Builder.setHdrMode(int) instead.

This PR makes new functions without the request parameter, and deprecates the old ones.