### PR TITLE
Fix: ANR when observing progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <p align="center">
     <a href="https://jitpack.io/#dev.transformerkt/transformerkt"><img src="https://jitpack.io/v/dev.transformerkt/transformerkt.svg"></a>
     <a href="https://github.com/jordond/transformerKt/actions/workflows/ci.yml"><img src="https://github.com/jordond/transformerKt/actions/workflows/ci.yml/badge.svg"></img></a>
-    <a href="https://developer.android.com/jetpack/androidx/releases/media3#1.2.0-alpha02"><img src="https://img.shields.io/badge/media3-1.2.0-alpha02-brightgreen" /></a>
+    <a href="https://developer.android.com/jetpack/androidx/releases/media3#1.2.0-beta01"><img src="https://img.shields.io/badge/media3-1.2.0-beta01-brightgreen" /></a>
     <img src="https://img.shields.io/github/license/jordond/transformerkt" />   
 </p>
 
@@ -18,7 +18,7 @@ around [media3.transformer](https://developer.android.com/guide/topics/media/tra
 You can view the TransformerKt KDocs at [docs.transformerkt.dev](https://docs.transformerkt.dev)
 
 - Using `media3.transformer`
-  version [`1.2.0-alpha02`](https://github.com/androidx/media/releases)
+  version [`1.2.0-beta01`](https://github.com/androidx/media/releases)
 
 ## Table of Contents
 


### PR DESCRIPTION
Fixes #62 

A race condition would happen where we would loop forever because we weren't properly checking the return value of `Transformer.getProgress()`