### PR TITLE
Feature: Add VolumeChangeProcessor for dynamically changing volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,44 @@ Checkout
 the [`TransformerRepo.kt`](demo/src/main/java/dev/transformerkt/demo/transformer/TransformerRepo.kt)
 file for more examples.
 
+## Included Effects
+
+Currently only one custom effect is included in this library. It is the `AudioProcessor`
+called `VolumeChangeProcessor`. It allows you to change the volume of the audio track in the video.
+
+```kotlin
+val volumeChange = volumeChangeEffect(inputChannels = 2, volume = 0.5f)
+// ... Add to your EditedMediaItemSequence
+```
+
+If you provide a `VolumeChangeProcessor` you are able to customize the volume based on the elapsed
+time in the output video:
+
+```kotlin
+val volumeChange = volumeChangeEffect(inputChannels = 2) { elapsedMs ->
+    when {
+        elapsedMs < 1000 -> 0f
+        elapsedMs < 2000 -> 0.5f
+        else -> 1f
+    }
+}
+```
+
+For convenience there is a `fadeAudioOutEffect` that will fade the audio out over a given duration:
+
+```kotlin
+val volumeChange = fadeAudioOutEffect(
+    totalDurationUs = 10_000_000,
+    inputChannels = 2,
+    initialVolume = 0.8f,
+    finalVolume = 0.3f,
+    fadeDurationUs = 2_000_000,
+)
+```
+
+This effect will fade the audio from `0.8f` to `0.3f` over the course of `2_000_000` microseconds
+(2 seconds) from the end of the video.
+
 ## Demo App
 
 A demo app is included in the `demo` module. It is a simple app that allows you to select a HDR

--- a/demo/src/main/java/dev/transformerkt/demo/ui/effects/EffectSettings.kt
+++ b/demo/src/main/java/dev/transformerkt/demo/ui/effects/EffectSettings.kt
@@ -14,4 +14,5 @@ data class EffectSettings(
 data class AudioOverlay(
     val uri: Uri,
     val volume: Float = 1f,
+    val fade: Boolean = false,
 )

--- a/demo/src/main/java/dev/transformerkt/demo/ui/effects/EffectsModel.kt
+++ b/demo/src/main/java/dev/transformerkt/demo/ui/effects/EffectsModel.kt
@@ -44,6 +44,12 @@ class EffectsModel @Inject constructor(
         }
     }
 
+    fun updateAudioOverlay(overlay: AudioOverlay) {
+        _state.update { state ->
+            state.copy(settings = state.settings.copy(audioOverlay = overlay))
+        }
+    }
+
     fun selectAudioUri(uri: Uri) {
         _state.update { state ->
             val audio = state.settings.audioOverlay?.copy(uri = uri) ?: AudioOverlay(uri)

--- a/demo/src/main/java/dev/transformerkt/demo/ui/effects/EffectsScreen.kt
+++ b/demo/src/main/java/dev/transformerkt/demo/ui/effects/EffectsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -59,6 +60,7 @@ fun EffectsScreen() {
         updateSettings = { model.updateSettings(it) },
         onSelectUri = { model.selectUri(it) },
         onSelectAudioUri = { model.selectAudioUri(it) },
+        updateAudioOverlay = { model.updateAudioOverlay(it) },
         onStart = { model.start() },
         onCancel = { model.cancel() },
     )
@@ -215,6 +217,22 @@ fun EffectsContent(
                             onValueChangeFinished = {
                                 updateAudioOverlay(state.settings.audioOverlay.copy(volume = volume))
                             },
+                        )
+                    }
+                }
+
+                if (state.settings.audioOverlay != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(text = "Fade Audio Overlay: ")
+                        Checkbox(
+                            checked = state.settings.audioOverlay.fade,
+                            onCheckedChange = { value ->
+                                updateAudioOverlay(state.settings.audioOverlay.copy(fade = value))
+                            }
                         )
                     }
                 }

--- a/transformerkt/src/main/java/dev/transformerkt/effects/VolumeChangeProcessor.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/effects/VolumeChangeProcessor.kt
@@ -1,0 +1,86 @@
+package dev.transformerkt.effects
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioMixingUtil
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import androidx.media3.common.audio.ChannelMixingAudioProcessor
+import androidx.media3.common.audio.ChannelMixingMatrix
+import androidx.media3.common.util.Util
+import java.nio.ByteBuffer
+
+/**
+ * An AudioProcessor that handles changing the volume on an audio channel.
+ *
+ * Input and output are 16-bit PCM.
+ *
+ * Inspired by [ChannelMixingAudioProcessor].
+ *
+ * @param[inputChannels] The number of input channels.
+ * @param[outputChannels] The number of output channels.
+ * @param[volumeChangeProvider] A provider that returns the volume for a given time.
+ */
+public class VolumeChangeProcessor(
+    inputChannels: Int,
+    outputChannels: Int,
+    private val volumeChangeProvider: VolumeChangeProvider,
+) : BaseAudioProcessor() {
+
+    private var bytesRead: Long = 0
+    private var currentVolume: Float = 1f
+
+    private var channelMixingMatrix = ChannelMixingMatrix
+        .create(inputChannels, outputChannels)
+        .scaleBy(volumeChangeProvider.initial)
+
+    override fun onConfigure(
+        inputAudioFormat: AudioProcessor.AudioFormat,
+    ): AudioProcessor.AudioFormat {
+        if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT) {
+            throw AudioProcessor.UnhandledAudioFormatException(inputAudioFormat)
+        }
+
+        return AudioProcessor.AudioFormat(
+            /* sampleRate = */ inputAudioFormat.sampleRate,
+            /* channelCount = */ channelMixingMatrix.outputChannelCount,
+            /* encoding = */ C.ENCODING_PCM_16BIT,
+        )
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        bytesRead += inputBuffer.remaining()
+
+        val timeUs = Util.scaleLargeTimestamp(
+            /* timestamp = */ bytesRead,
+            /* multiplier = */ C.MICROS_PER_SECOND,
+            /* divisor = */ inputAudioFormat.sampleRate.toLong() * inputAudioFormat.bytesPerFrame
+        )
+
+        val newVolume: Float = volumeChangeProvider.getVolume(timeUs)
+        check(newVolume >= 0f) { "Volume must not be negative, received: $newVolume" }
+
+        if (newVolume != currentVolume) {
+            currentVolume = newVolume
+            channelMixingMatrix = channelMixingMatrix.scaleBy(newVolume)
+            flush()
+        }
+
+        val framesToMix = inputBuffer.remaining() / inputAudioFormat.bytesPerFrame
+        val outputBuffer = replaceOutputBuffer(framesToMix * outputAudioFormat.bytesPerFrame)
+        AudioMixingUtil.mix(
+            /* inputBuffer = */ inputBuffer,
+            /* inputAudioFormat = */ inputAudioFormat,
+            /* mixingBuffer = */ outputBuffer,
+            /* mixingAudioFormat = */ outputAudioFormat,
+            /* matrix = */ channelMixingMatrix,
+            /* framesToMix = */ framesToMix,
+            /* accumulate= */ false
+        )
+        outputBuffer.flip()
+    }
+
+    override fun onReset() {
+        currentVolume = 1f
+        bytesRead = 0
+    }
+}

--- a/transformerkt/src/main/java/dev/transformerkt/effects/VolumeChangeProvider.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/effects/VolumeChangeProvider.kt
@@ -1,8 +1,17 @@
 package dev.transformerkt.effects
 
+/**
+ * Provide volume for [VolumeChangeProcessor].
+ */
 public interface VolumeChangeProvider {
 
+    /**
+     * The initial volume to start with.
+     */
     public val initial: Float
 
+    /**
+     * Calculate the volume for the given time.
+     */
     public fun getVolume(timeUs: Long): Float
 }

--- a/transformerkt/src/main/java/dev/transformerkt/effects/VolumeChangeProvider.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/effects/VolumeChangeProvider.kt
@@ -1,0 +1,8 @@
+package dev.transformerkt.effects
+
+public interface VolumeChangeProvider {
+
+    public val initial: Float
+
+    public fun getVolume(timeUs: Long): Float
+}

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/effects/FadeAudioOut.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/effects/FadeAudioOut.kt
@@ -1,0 +1,117 @@
+package dev.transformerkt.ktx.effects
+
+import dev.transformerkt.dsl.effects.EffectsBuilder
+import dev.transformerkt.effects.VolumeChangeProcessor
+import dev.transformerkt.effects.VolumeChangeProvider
+import java.util.concurrent.TimeUnit
+
+/**
+ * Creates an [VolumeChangeProvider] that you can use to fade the audio out at the end of the video.
+ *
+ * @param[totalDurationUs] The total duration of the video in microseconds.
+ * @param[inputChannels] The number of input channels.
+ * @param[outputChannels] The number of output channels (defaults to stereo - 2).
+ * @param[initialVolume] The initial volume of the audio stream.
+ * @param[finalVolume] The final volume of the audio stream.
+ * @param[fadeDurationUs] The duration of the fade out in microseconds.
+ */
+public fun fadeAudioOutEffect(
+    totalDurationUs: Long,
+    inputChannels: Int,
+    outputChannels: Int = 2,
+    initialVolume: Float = 1f,
+    finalVolume: Float = 0f,
+    fadeDurationUs: Long = TimeUnit.SECONDS.toMicros(1),
+): VolumeChangeProcessor {
+    val provider = fadeAudioOutProvider(
+        totalDurationUs = totalDurationUs,
+        initialVolume = initialVolume,
+        finalVolume = finalVolume,
+        fadeDurationUs = fadeDurationUs,
+    )
+    return volumeChangeEffect(
+        inputChannels = inputChannels,
+        outputChannels = outputChannels,
+        volumeChangeProvider = provider,
+    )
+}
+
+/**
+ * Add an [VolumeChangeProcessor] to the [EffectsBuilder] that you can use to fade the audio out at
+ * the end of the video.
+ *
+ * @param[totalDurationUs] The total duration of the video in microseconds.
+ * @param[inputChannels] The number of input channels.
+ * @param[outputChannels] The number of output channels (defaults to stereo - 2).
+ * @param[initialVolume] The initial volume of the audio stream.
+ * @param[finalVolume] The final volume of the audio stream.
+ * @param[fadeDurationUs] The duration of the fade out in microseconds.
+ */
+public fun EffectsBuilder.fadeAudioOut(
+    totalDurationUs: Long,
+    inputChannels: Int,
+    outputChannels: Int = 2,
+    initialVolume: Float = 1f,
+    finalVolume: Float = 0f,
+    fadeDurationUs: Long = TimeUnit.SECONDS.toMicros(1),
+): EffectsBuilder = apply {
+    audio(
+        fadeAudioOutEffect(
+            totalDurationUs = totalDurationUs,
+            inputChannels = inputChannels,
+            outputChannels = outputChannels,
+            initialVolume = initialVolume,
+            finalVolume = finalVolume,
+            fadeDurationUs = fadeDurationUs,
+        )
+    )
+}
+
+/**
+ * Creates an [VolumeChangeProvider] that you can use to fade the audio out at the end of the video.
+ *
+ * @param[totalDurationUs] The total duration of the video in microseconds.
+ * @param[initialVolume] The initial volume of the audio stream.
+ * @param[finalVolume] The final volume of the audio stream.
+ * @param[fadeDurationUs] The duration of the fade out in microseconds.
+ */
+private fun fadeAudioOutProvider(
+    totalDurationUs: Long,
+    initialVolume: Float,
+    finalVolume: Float,
+    fadeDurationUs: Long,
+): VolumeChangeProvider = object : VolumeChangeProvider {
+
+    override val initial: Float = initialVolume
+
+    override fun getVolume(timeUs: Long): Float = fadeAudioOut(
+        totalDurationUs = totalDurationUs,
+        fadeDurationUs = fadeDurationUs,
+        currentTimeUs = timeUs,
+        finalVolume = finalVolume,
+    )
+}
+
+/**
+ * A convenience function that calculates the volume value in order to fade the audio out at the
+ * end of the video.
+ *
+ * @param[totalDurationUs] The total duration of the video in microseconds.
+ * @param[fadeDurationUs] The duration of the fade out in microseconds.
+ * @param[currentTimeUs] The current time of the video in microseconds.
+ * @param[finalVolume] The final volume of the audio stream.
+ */
+private fun VolumeChangeProvider.fadeAudioOut(
+    totalDurationUs: Long,
+    fadeDurationUs: Long,
+    currentTimeUs: Long,
+    finalVolume: Float,
+): Float {
+    val fadeOutStart = totalDurationUs - fadeDurationUs
+    return if (currentTimeUs < fadeOutStart) initial
+    else {
+        val fadeoutElapsedTime = currentTimeUs - fadeOutStart
+        val fadeOutProgress = fadeoutElapsedTime.toFloat() / fadeDurationUs.toFloat()
+        initial - (initial - finalVolume) * fadeOutProgress
+    }
+}

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/effects/Volume.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/effects/Volume.kt
@@ -7,6 +7,10 @@ import androidx.media3.common.audio.ChannelMixingMatrix
 import dev.transformerkt.dsl.effects.EffectsBuilder
 
 @CheckResult
+@Deprecated(
+    message = "Use volumeChangeEffect instead",
+    replaceWith = ReplaceWith("volumeChangeEffect(inputChannels, volume, outputChannels)"),
+)
 public fun volumeEffect(
     volume: Float,
     inputChannels: Int,
@@ -21,5 +25,5 @@ public fun EffectsBuilder.volume(
     inputChannels: Int,
     outputChannels: Int = 2,
 ): EffectsBuilder = apply {
-    audio(volumeEffect(volume, inputChannels, outputChannels))
+    volumeChange(inputChannels, volume, outputChannels)
 }

--- a/transformerkt/src/main/java/dev/transformerkt/ktx/effects/VolumeChange.kt
+++ b/transformerkt/src/main/java/dev/transformerkt/ktx/effects/VolumeChange.kt
@@ -1,0 +1,94 @@
+package dev.transformerkt.ktx.effects
+
+import androidx.annotation.CheckResult
+import dev.transformerkt.dsl.effects.EffectsBuilder
+import dev.transformerkt.effects.VolumeChangeProcessor
+import dev.transformerkt.effects.VolumeChangeProvider
+
+/**
+ * Creates an [VolumeChangeProcessor] that you can use to change the volume of an audio stream over time.
+ *
+ * @param[inputChannels] The number of input channels.
+ * @param[outputChannels] The number of output channels (defaults to stereo - 2).
+ * @param[volumeChangeProvider] The [VolumeChangeProvider] that will provide the volume change over time.
+ */
+@CheckResult
+public fun volumeChangeEffect(
+    inputChannels: Int,
+    outputChannels: Int = 2,
+    volumeChangeProvider: VolumeChangeProvider,
+): VolumeChangeProcessor = VolumeChangeProcessor(
+    inputChannels = inputChannels,
+    outputChannels = outputChannels,
+    volumeChangeProvider = volumeChangeProvider,
+)
+
+/**
+ * Add [VolumeChangeProcessor] effect that you can use to change the volume of the audio
+ * stream over time.
+ *
+ * @param[inputChannels] The number of input channels.
+ * @param[outputChannels] The number of output channels (defaults to stereo - 2).
+ * @param[volumeChangeProvider] The [VolumeChangeProvider] that will provide the volume change over time.
+ */
+public fun EffectsBuilder.volumeChange(
+    inputChannels: Int,
+    outputChannels: Int = 2,
+    volumeChangeProvider: VolumeChangeProvider,
+): EffectsBuilder = apply {
+    audio(
+        volumeChangeEffect(
+            inputChannels = inputChannels,
+            outputChannels = outputChannels,
+            volumeChangeProvider = volumeChangeProvider,
+        )
+    )
+}
+
+/**
+ * Creates an [VolumeChangeProcessor] that you can use to change the volume of an audio stream over time.
+ *
+ * @param[inputChannels] The number of input channels.
+ * @param[outputChannels] The number of output channels (defaults to stereo - 2).
+ * @param[volume] The initial volume of the audio stream.
+ * @param[volumeChange] The function that will provide the volume change over time.
+ */
+@CheckResult
+public fun volumeChangeEffect(
+    inputChannels: Int,
+    volume: Float = 1f,
+    outputChannels: Int = 2,
+    volumeChange: VolumeChangeProvider.(timeUs: Long) -> Float = { volume },
+): VolumeChangeProcessor = VolumeChangeProcessor(
+    inputChannels = inputChannels,
+    outputChannels = outputChannels,
+    volumeChangeProvider = object : VolumeChangeProvider {
+        override val initial: Float = volume
+        override fun getVolume(timeUs: Long): Float = volumeChange(timeUs)
+    }
+)
+
+/**
+ * Add [VolumeChangeProcessor] effect that you can use to change the volume of the audio
+ * stream over time.
+ *
+ * @param[inputChannels] The number of input channels.
+ * @param[outputChannels] The number of output channels (defaults to stereo - 2).
+ * @param[volume] The initial volume of the audio stream.
+ * @param[volumeChange] The function that will provide the volume change over time.
+ */
+public fun EffectsBuilder.volumeChange(
+    inputChannels: Int,
+    volume: Float = 1f,
+    outputChannels: Int = 2,
+    volumeChange: VolumeChangeProvider.(timeUs: Long) -> Float = { volume },
+): EffectsBuilder = apply {
+    audio(
+        volumeChangeEffect(
+            inputChannels = inputChannels,
+            outputChannels = outputChannels,
+            volume = volume,
+            volumeChange = volumeChange,
+        )
+    )
+}


### PR DESCRIPTION
Add `VolumeChangeProcessor`. It allows you to change the volume of the audio track in the video.

```kotlin
val volumeChange = volumeChangeEffect(inputChannels = 2, volume = 0.5f)
// ... Add to your EditedMediaItemSequence
```

If you provide a `VolumeChangeProcessor` you are able to customize the volume based on the elapsed
time in the output video:

```kotlin
val volumeChange = volumeChangeEffect(inputChannels = 2) { elapsedMs ->
    when {
        elapsedMs < 1000 -> 0f
        elapsedMs < 2000 -> 0.5f
        else -> 1f
    }
}
```

For convenience there is a `fadeAudioOutEffect` that will fade the audio out over a given duration:

```kotlin
val volumeChange = fadeAudioOutEffect(
    totalDurationUs = 10_000_000,
    inputChannels = 2,
    initialVolume = 0.8f,
    finalVolume = 0.3f,
    fadeDurationUs = 2_000_000,
)
```

This effect will fade the audio from `0.8f` to `0.3f` over the course of `2_000_000` microseconds
(2 seconds) from the end of the video.